### PR TITLE
Generate territority list solely from Wynn api

### DIFF
--- a/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
@@ -7,7 +7,6 @@ import com.wynntils.athena.core.configs.apiConfig
 import com.wynntils.athena.core.configs.generalConfig
 import com.wynntils.athena.core.utils.JSONOrderedObject
 import com.wynntils.athena.routes.managers.GuildManager
-import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import java.net.URL
 import java.nio.charset.StandardCharsets
@@ -16,17 +15,10 @@ import java.nio.charset.StandardCharsets
 class TerritoryListCache: DataCache {
 
     /**
-     * Generates the cache based on merging Wynn and Scyu's Territory Data
+     * Generates the cache based on Wynn's Territory Data
      */
     override fun generateCache(): JSONOrderedObject {
-        var connection = URL(apiConfig.scyuTerritories).openConnection()
-        connection.setRequestProperty("User-Agent", generalConfig.userAgent)
-        connection.readTimeout = 5000
-        connection.connectTimeout = 5000
-
-        val scyuTerritories =  connection.getInputStream().readBytes().toString(StandardCharsets.UTF_8).asJSON<JSONArray>()
-
-        connection = URL(apiConfig.wynnTerritories).openConnection()
+        val connection = URL(apiConfig.wynnTerritories).openConnection()
         connection.setRequestProperty("User-Agent", generalConfig.userAgent)
         connection.setRequestProperty("apikey", apiConfig.wynnApiToken)
 
@@ -38,36 +30,22 @@ class TerritoryListCache: DataCache {
 
         val response = JSONOrderedObject()
         val result = response.getOrCreate<JSONOrderedObject>("territories")
-        for(territory in scyuTerritories) {
-            territory as JSONObject
+        for(name in wynnTerritories.keys) {
+            name as String
 
-            val name = territory["name"] as String
             val wynn = wynnTerritories[name] as JSONObject
-
             val final = result.getOrCreate<JSONOrderedObject>(name)
-
-            // location stuff
-            val start = territory["start"].toString().split(",")
-            val end = territory["end"].toString().split(",")
-
-            val location = final.getOrCreate<JSONOrderedObject>("location")
-            location["startX"] = start[0].toInt()
-            location["startZ"] = start[1].toInt()
-            location["endX"] = end[0].toInt()
-            location["endZ"] = end[1].toInt()
-            location["spawn"] = territory["spawnLocation"]
 
             val guild = GuildManager.getGuildData(wynn["guild"] as String)!!
 
-            // merging stuff
             final["territory"] = wynn["territory"]
             final["guild"] = guild.id
             final["guildPrefix"] = guild.prefix
             final["guildColor"] = guild.color
             final["acquired"] = wynn["acquired"]
             final["attacker"] = wynn["attacker"]
-            final["level"] = territory["level"]
-            final["location"] = location
+            final["level"] = 1 // not used
+            final["location"] = wynn["location"]
         }
 
         return response

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
@@ -46,8 +46,14 @@ class TerritoryListCache: DataCache {
             final["attacker"] = wynn["attacker"]
             final["level"] = 1 // not used
 
-            if (wynn.containsKey("location")) // some territories have missing location data
-                final["location"] = wynn["location"]
+            if (wynn.containsKey("location")) {// some territories have missing location data
+                val location = final.getOrCreate<JSONOrderedObject>("location")
+                val wynnLocation = wynn["location"] as JSONObject
+                location["startX"] = wynnLocation["startX"]
+                location["startZ"] = wynnLocation["startY"] // y-z mismatch
+                location["endX"] = wynnLocation["endX"]
+                location["endZ"] = wynnLocation["endY"]
+            }
         }
 
         return response

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/TerritoryListCache.kt
@@ -45,7 +45,9 @@ class TerritoryListCache: DataCache {
             final["acquired"] = wynn["acquired"]
             final["attacker"] = wynn["attacker"]
             final["level"] = 1 // not used
-            final["location"] = wynn["location"]
+
+            if (wynn.containsKey("location")) // some territories have missing location data
+                final["location"] = wynn["location"]
         }
 
         return response


### PR DESCRIPTION
Iterates through every entry in the Wynn territory list to generate the necessary data.

The level field seems to be unused in Wynntils itself, so setting each entry to 1 should be fine unless something is planned for it.