### PR TITLE
Add major id list to item cache

### DIFF
--- a/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
+++ b/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
@@ -1,5 +1,7 @@
 package com.wynntils.athena.database.enums
 
+import com.wynntils.athena.core.utils.JSONOrderedObject
+
 enum class MajorIdentification(
 
     val displayname: String,
@@ -29,6 +31,15 @@ enum class MajorIdentification(
     FURIOUS_EFFIGY("Furious Effigy", "Totem effects are twice as fast, but duration is halved"),
     FLASHFREEZE("Flash Freeze", "Ice Snake is instant but has a reduced range"),
     FISSION("Fission", "Explosions from your \"Exploding\" ID are twice as big and twice as strong"),
-    EXPLOSIVE_IMPACT("Explosive Impact", "Your \"Exploding\" ID can trigger when hitting mobs with your basic attack")
+    EXPLOSIVE_IMPACT("Explosive Impact", "Your \"Exploding\" ID can trigger when hitting mobs with your basic attack");
+
+    fun getJSON() : JSONOrderedObject {
+        val result = JSONOrderedObject()
+
+        result["name"] = displayname
+        result["description"] = description
+
+        return result
+    }
 
 }

--- a/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
+++ b/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
@@ -1,7 +1,5 @@
 package com.wynntils.athena.database.enums
 
-import com.wynntils.athena.core.utils.JSONOrderedObject
-
 enum class MajorIdentification(
 
     val displayname: String,
@@ -31,15 +29,6 @@ enum class MajorIdentification(
     FURIOUS_EFFIGY("Furious Effigy", "Totem effects are twice as fast, but duration is halved"),
     FLASHFREEZE("Flash Freeze", "Ice Snake is instant but has a reduced range"),
     FISSION("Fission", "Explosions from your \"Exploding\" ID are twice as big and twice as strong"),
-    EXPLOSIVE_IMPACT("Explosive Impact", "Your \"Exploding\" ID can trigger when hitting mobs with your basic attack");
-
-    fun getJSON() : JSONOrderedObject {
-        val result = JSONOrderedObject()
-
-        result["name"] = displayname
-        result["description"] = description
-
-        return result
-    }
+    EXPLOSIVE_IMPACT("Explosive Impact", "Your \"Exploding\" ID can trigger when hitting mobs with your basic attack")
 
 }

--- a/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
+++ b/src/main/kotlin/com/wynntils/athena/database/enums/MajorIdentification.kt
@@ -1,0 +1,34 @@
+package com.wynntils.athena.database.enums
+
+enum class MajorIdentification(
+
+    val displayname: String,
+    val description: String
+
+) {
+
+    PLAGUE("Plague", "Poisoned mobs spread their poison to nearby mobs"),
+    HAWKEYE("Hawkeye", "Arrow storm fires 5 arrows each dealing 80% damage"),
+    GREED("Greed", "Picking up emeralds heals you and nearby players for 15% max health"),
+    CAVALRYMAN("Cavalryman", "You may cast spells and attack with a 70% damage penalty while on a horse"),
+    GUARDIAN("Guardian", "50% of damage taken by nearby allies is redirected to you"),
+    ALTRUISM("Heart of the Pack", "Nearby players gain 35% of the health you naturally regenerate"),
+    HERO("Saviour's Sacrifice", "While under 50% maximum health, nearby allies gain 50% bonus damage and defence"),
+    ARCANES("Transcendence", "50% chance for spells to cost no mana when casted"),
+    ENTROPY("Entropy", "Meteor falls three times faster"),
+    ROVINGASSASSIN("Roving Assassin", "Vanish no longer drains mana while invisible"),
+    MAGNET("Magnet", "Pulls items within an 8 block radius towards you"),
+    MADNESS("Madness", "Casts a random ability every 3 seconds"),
+    LIGHTWEIGHT("Lightweight", "You no longer take fall damage"),
+    SORCERY("Sorcery", "30% chance for spells and attacks to cast a second time at no additional cost"),
+    TAUNT("Taunt", "Mobs within 12 blocks target you upon casting War Scream"),
+    FREERUNNER("Freerunner", "Double your sprint speed when your sprint bar is under 30%"),
+    RALLY("Rally", "Charge heals you by 10% and nearby allies by 15% on impact, but becomes harmless"),
+    CHERRY_BOMBS("Cherry Bombs", "Your Smoke Bombs explode instantly on contact, dealing 110% damage each"),
+    PEACEFUL_EFFIGY("Peaceful Effigy", "Your Totem will last twice as long"),
+    FURIOUS_EFFIGY("Furious Effigy", "Totem effects are twice as fast, but duration is halved"),
+    FLASHFREEZE("Flash Freeze", "Ice Snake is instant but has a reduced range"),
+    FISSION("Fission", "Explosions from your \"Exploding\" ID are twice as big and twice as strong"),
+    EXPLOSIVE_IMPACT("Explosive Impact", "Your \"Exploding\" ID can trigger when hitting mobs with your basic attack")
+
+}

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
@@ -55,7 +55,7 @@ class ItemListCache: DataCache {
             itemsMap[item["name"] as String] = converted
             items.add(converted)
         }
-        
+
         val wynnBuilder = URL(apiConfig.wynnBuilderIDs).openConnection()
         wynnBuilder.setRequestProperty("User-Agent", generalConfig.userAgent)
         wynnBuilder.readTimeout = 20000
@@ -73,6 +73,7 @@ class ItemListCache: DataCache {
 
         result["identificationOrder"] = ItemManager.getIdentificationOrder()
         result["internalIdentifications"] = ItemManager.getInternalIdentifications()
+        result["majorIdentifications"] = ItemManager.getMajorIdentifications()
 
         return result
     }

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
@@ -73,7 +73,6 @@ class ItemListCache: DataCache {
 
         result["identificationOrder"] = ItemManager.getIdentificationOrder()
         result["internalIdentifications"] = ItemManager.getInternalIdentifications()
-        result["majorIdentifications"] = ItemManager.getMajorIdentifications()
 
         return result
     }

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
@@ -73,6 +73,7 @@ class ItemListCache: DataCache {
 
         result["identificationOrder"] = ItemManager.getIdentificationOrder()
         result["internalIdentifications"] = ItemManager.getInternalIdentifications()
+        result["majorIdentifications"] = ItemManager.getMajorIdentifications()
 
         return result
     }

--- a/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
@@ -87,16 +87,6 @@ object ItemManager {
         // Pure Copy
         val statuses = result.getOrCreate<JSONOrderedObject>("statuses")
 
-        if (input.containsKey("majorIds")) {
-            val majorIds = result.getOrCreate<JSONArray>("majorIdentifications")
-
-            for (id in input["majorIds"] as JSONArray) {
-                try {
-                    majorIds.add(MajorIdentification.valueOf(id as String).getJSON())
-                } catch (e: IllegalArgumentException) { } // missing major id
-            }
-        }
-
         result["majorIds"] = input.getOrDefault("majorIds", null)
         result["restriction"] = input["restrictions"]
         result["lore"] = input["addedLore"]
@@ -270,6 +260,18 @@ object ItemManager {
         result["WATERDEFENSE"] = "waterDefence"
         result["FIREDEFENSE"] = "fireDefence"
         result["AIRDEFENSE"] = "airDefence"
+
+        return result
+    }
+
+    fun getMajorIdentifications(): JSONOrderedObject {
+        val result = JSONOrderedObject()
+
+        for (id in MajorIdentification.values()) {
+            val entry = result.getOrCreate<JSONOrderedObject>(id.name)
+            entry["name"] = id.displayname
+            entry["description"] = id.description
+        }
 
         return result
     }

--- a/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
@@ -87,6 +87,16 @@ object ItemManager {
         // Pure Copy
         val statuses = result.getOrCreate<JSONOrderedObject>("statuses")
 
+        if (input.containsKey("majorIds")) {
+            val majorIds = result.getOrCreate<JSONArray>("majorIdentifications")
+
+            for (id in input["majorIds"] as JSONArray) {
+                try {
+                    majorIds.add(MajorIdentification.valueOf(id as String).getJSON())
+                } catch (e: IllegalArgumentException) { } // missing major id
+            }
+        }
+
         result["majorIds"] = input.getOrDefault("majorIds", null)
         result["restriction"] = input["restrictions"]
         result["lore"] = input["addedLore"]
@@ -260,18 +270,6 @@ object ItemManager {
         result["WATERDEFENSE"] = "waterDefence"
         result["FIREDEFENSE"] = "fireDefence"
         result["AIRDEFENSE"] = "airDefence"
-
-        return result
-    }
-
-    fun getMajorIdentifications(): JSONOrderedObject {
-        val result = JSONOrderedObject()
-
-        for (id in MajorIdentification.values()) {
-            val entry = result.getOrCreate<JSONOrderedObject>(id.name)
-            entry["name"] = id.displayname
-            entry["description"] = id.description
-        }
 
         return result
     }

--- a/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
@@ -1,6 +1,7 @@
 package com.wynntils.athena.routes.managers
 
 import com.wynntils.athena.core.utils.JSONOrderedObject
+import com.wynntils.athena.database.enums.MajorIdentification
 import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 
@@ -209,10 +210,10 @@ object ItemManager {
 
         return result
     }
-	
+
     fun getInternalIdentifications(): JSONOrderedObject {
         val result = JSONOrderedObject()
-    	
+
         result["STRENGTHPOINTS"] = "rawStrength"
         result["DEXTERITYPOINTS"] = "rawDexterity"
         result["INTELLIGENCEPOINTS"] = "rawIntelligence"
@@ -259,7 +260,19 @@ object ItemManager {
         result["WATERDEFENSE"] = "waterDefence"
         result["FIREDEFENSE"] = "fireDefence"
         result["AIRDEFENSE"] = "airDefence"
-    	
+
+        return result
+    }
+
+    fun getMajorIdentifications(): JSONOrderedObject {
+        val result = JSONOrderedObject()
+
+        for (id in MajorIdentification.values()) {
+            val entry = result.getOrCreate<JSONOrderedObject>(id.name)
+            entry["name"] = id.displayname
+            entry["description"] = id.description
+        }
+
         return result
     }
 


### PR DESCRIPTION
Moves the list of major identifications to Athena to avoid the bad practice of hard coding them into the mod