### PR TITLE
Add ability to manually define item changes

### DIFF
--- a/src/main/kotlin/com/wynntils/athena/core/configs/instances/ApiConfig.kt
+++ b/src/main/kotlin/com/wynntils/athena/core/configs/instances/ApiConfig.kt
@@ -17,6 +17,7 @@ data class ApiConfig (
     val npcLocations: String = "https://raw.githubusercontent.com/Wynntils/Data-Storage/master/npc-locations.json",
 
     val wynnItems: String = "https://api.wynncraft.com/public_api.php?action=itemDB&category=all",
+    val wynnItemChanges: String = "https://raw.githubusercontent.com/Wynntils/Data-Storage/master/item-changes.json",
 
     val wynnGuildInfo: String = "https://api.wynncraft.com/public_api.php?action=guildStats&command=",
 

--- a/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/caches/ItemListCache.kt
@@ -30,6 +30,15 @@ class ItemListCache: DataCache {
         val input = connection.getInputStream().readBytes().toString(StandardCharsets.UTF_8).asJSON<JSONObject>()
         if (!input.containsKey("items")) throw UnexpectedCacheResponse()
 
+        val changelog = URL(apiConfig.wynnItemChanges).openConnection()
+        changelog.setRequestProperty("User-Agent", generalConfig.userAgent)
+        changelog.readTimeout = 20000
+        changelog.connectTimeout = 20000
+
+        val changelogInput = changelog.getInputStream().readBytes().toString(StandardCharsets.UTF_8).asJSON<JSONObject>()
+        val changes = changelogInput.getOrCreate<JSONObject>("changes")
+        val newItems = changelogInput.getOrCreate<JSONArray>("items")
+
         val result = JSONOrderedObject()
         val items = result.getOrCreate<JSONArray>("items")
 
@@ -41,19 +50,30 @@ class ItemListCache: DataCache {
         for (i in originalItems) {
             val item = i as JSONObject
 
-            // store all item material types
+            // convert item and apply changes, if necessary
             val converted = ItemManager.convertItem(item)
+            if (changes.containsKey(converted["displayName"])) {
+                ItemManager.updateItem(converted, changes)
+            }
+
+            // store all item material types
             if (converted["itemInfo"] != null) {
                 val itemInfo = converted["itemInfo"] as JSONOrderedObject
-                val typeArray = materialTypes.getOrCreate<JSONArray>(itemInfo["type"] as String);
+                val typeArray = materialTypes.getOrCreate<JSONArray>(itemInfo["type"] as String)
 
-                val material = itemInfo["material"];
+                val material = itemInfo["material"]
                 if (material != null && !typeArray.contains(material)) typeArray.add(material)
             }
 
             if (item.containsKey("displayName")) translatedReferences[item["name"]] = item["displayName"]
             itemsMap[item["name"] as String] = converted
             items.add(converted)
+        }
+
+        // add new items from changelog
+        for (i in newItems) {
+            val item = i as JSONObject
+            items.add(item)
         }
 
         val wynnBuilder = URL(apiConfig.wynnBuilderIDs).openConnection()

--- a/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
@@ -139,13 +139,16 @@ object ItemManager {
             val statuses = item.getOrCreate<JSONOrderedObject>("statuses")
             val changed = changes["statuses"] as JSONObject
             for (key in changed.keys) {
-                val value = changed[key] as Number
+                val changedStatus = changed[key] as JSONObject
+                val value = changedStatus["baseValue"] as Number
                 if (value.toInt() == 0) {
                     statuses.remove(key)
                     continue
                 }
 
                 val status = statuses.getOrCreate<JSONOrderedObject>(key as String)
+                status["type"] = changedStatus["type"]
+                status["isFixed"] = changedStatus["isFixed"]
                 status["baseValue"] = value
             }
         }

--- a/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/managers/ItemManager.kt
@@ -31,14 +31,6 @@ object ItemManager {
             else "PERCENTAGE"
         }
 
-        fun ignoreZero(input: Any?): Any? {
-            if (input == null) return null
-
-            if (input is Number) return if (input.toInt() == 0) null else input
-            else if (input is String) return if (input.isEmpty() || input == "0-0") return null else input
-            return input
-        }
-
         // outside tags
         result["displayName"] = if (input.containsKey("displayName")) input["displayName"] else (input["name"] as String).replace("֎", "") // cancer has ֎ in it name for a random reason
         result["tier"] = (input["tier"] as String).toUpperCase()
@@ -121,6 +113,42 @@ object ItemManager {
         result.cleanNull()
 
         return result
+    }
+
+    fun updateItem(item: JSONOrderedObject, changelog: JSONObject) {
+        fun updateCategory(item: JSONOrderedObject, changes: JSONObject, category: String) {
+            if (changes.containsKey(category)) {
+                val original = item.getOrCreate<JSONOrderedObject>(category)
+                val changed = changes[category] as JSONObject
+                for (key in changed.keys) {
+                    original[key] = ignoreZero(changed[key])
+                }
+                original.cleanNull()
+            }
+        }
+
+        val itemName = item["displayName"]
+        val changes = changelog[itemName] as JSONObject
+
+        updateCategory(item, changes, "requirements")
+        updateCategory(item, changes, "damageTypes")
+        updateCategory(item, changes, "defenseTypes")
+
+        // must be handled separately since structure is different
+        if (changes.containsKey("statuses")) {
+            val statuses = item.getOrCreate<JSONOrderedObject>("statuses")
+            val changed = changes["statuses"] as JSONObject
+            for (key in changed.keys) {
+                val value = changed[key] as Number
+                if (value.toInt() == 0) {
+                    statuses.remove(key)
+                    continue
+                }
+
+                val status = statuses.getOrCreate<JSONOrderedObject>(key as String)
+                status["baseValue"] = value
+            }
+        }
     }
 
     fun getIdentificationOrder(): JSONOrderedObject {
@@ -336,6 +364,14 @@ object ItemManager {
             "reflection" -> "reflection"
             else -> null
         }
+    }
+
+    private fun ignoreZero(input: Any?): Any? {
+        if (input == null) return null
+
+        if (input is Number) return if (input.toInt() == 0) null else input
+        else if (input is String) return if (input.isEmpty() || input == "0-0") return null else input
+        return input
     }
 
 }


### PR DESCRIPTION
Adds functionality that merges item changes defined in [Data Storage](https://raw.githubusercontent.com/Wynntils/Data-Storage/master/item-changes.json) with the Wynncraft API while generating the item list cache. This includes defining completely new items to append to the list.

One potential concern I had is that new items are appended as regular `JSONObject`s instead of `JSONOrderedObject`s, which means the elements within the item object have different orders. This appears to have no affect on Athena's ability to generate the cache, ~~and as far as I am aware it should not affect Wynntils clients reading the data~~, but I would appreciate confirmation on these two things.

**After testing, I can confirm that the irregular ordering has no effect on the client.**