### PR TITLE
Addition of new account types

### DIFF
--- a/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
+++ b/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
@@ -7,7 +7,9 @@ enum class AccountType {
     DONATOR,
     CONTENT_TEAM,
     HELPER,
-    MODERATOR;
+    MODERATOR,
+    DEVELOPER,
+    ADMINISTRATOR;
 
     companion object {
 

--- a/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
+++ b/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
@@ -5,10 +5,11 @@ enum class AccountType {
     NORMAL,
     BANNED,
     DONATOR,
-    CONTENT_TEAM,
+    CREATIVE_TEAM,
     HELPER,
     MODERATOR,
     DEVELOPER,
+    WEB_ADMINISTRATOR;
     ADMINISTRATOR;
 
     companion object {

--- a/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
+++ b/src/main/kotlin/com/wynntils/athena/core/enums/AccountType.kt
@@ -9,7 +9,7 @@ enum class AccountType {
     HELPER,
     MODERATOR,
     DEVELOPER,
-    WEB_ADMINISTRATOR;
+    WEB_ADMINISTRATOR,
     ADMINISTRATOR;
 
     companion object {


### PR DESCRIPTION
# Addition of new account types
This pull request will add two new account types for better permission management later on. These are `DEVELOPER`, `WEB_ADMINISTRATOR` and `ADMINISTRATOR`. 
`CONTENT_TEAM`got renamed to `CREATIVE_TEAM` to be more in sync with the Discord.

Once merged, we will have to update Wynntils to support these new tags.