### PR TITLE
Add API route for retrieving the item identification order

### DIFF
--- a/src/main/kotlin/com/wynntils/athena/routes/ApiRoutes.kt
+++ b/src/main/kotlin/com/wynntils/athena/routes/ApiRoutes.kt
@@ -12,6 +12,7 @@ import com.wynntils.athena.database.enums.TextureResolution
 import com.wynntils.athena.database.objects.ApiKeyProfile
 import com.wynntils.athena.database.objects.UserProfile
 import com.wynntils.athena.routes.managers.GuildManager
+import com.wynntils.athena.routes.managers.ItemManager
 import io.javalin.http.Context
 import org.json.simple.JSONArray
 import org.json.simple.JSONObject
@@ -32,7 +33,8 @@ import java.util.*
  *  POST /getUserByPassword/:apiKey
  *  POST /createApiKey/:apiKey
  *  POST /changeApiKey/:apiKey
- *  POST /getUserConfig/:apikEY
+ *  POST /getUserConfig/:apiKey
+ *  GET /getIdentificationOrder
  *  GET /timings
  */
 @BasePath("/api")
@@ -465,6 +467,11 @@ class ApiRoutes {
         response["messsage"] = "Successfully located user '${body["configName"]}' configuration."
         response["result"] = (configFiles[body["configName"]] as String).asJSON()
         return response
+    }
+
+    @Route(path = "/getIdentificationOrder", type = RouteType.GET)
+    fun getIdentificationOrder(ctx: Context): JSONOrderedObject {
+        return ItemManager.getIdentificationOrder()
     }
 
     /**


### PR DESCRIPTION
This should make it easier for external apps/mods to work with the Wynntils chat item format, since they no longer have to pull the full item list just to retrieve the identification order.

There's also an argument to be made for adopting some self-contained canonical ordering (e.g. alphabetical), but that's a conversation for some other time.